### PR TITLE
Added the missing command in the showHelp()

### DIFF
--- a/src/main/java/group3/p3network/SetupConsumerConfig.java
+++ b/src/main/java/group3/p3network/SetupConsumerConfig.java
@@ -107,7 +107,8 @@ public class SetupConsumerConfig {
     }
 
     private void showHelp() {
-        System.err.println("Syntax: hostname:port [directory]\n");
+        System.err.println("Syntax: threads hostname:port [directory]\n");
+        System.err.println("    threads   number of threads to run");
         System.err.println("    hostname  localhost or ip address in " +
             "the format of XXX.XXX.XXX.XXX");
         System.err.println("    port      port number");


### PR DESCRIPTION
The --help output of the Consumer app now has the "thread" command line argument.